### PR TITLE
Update

### DIFF
--- a/app_icon.inx
+++ b/app_icon.inx
@@ -11,23 +11,23 @@
     <dependency type="executable" location="extensions">app_icon.py</dependency>
 
     <param name="extension_description" type="description">This extension generates icon bundles for iOS and/or Android and/or MS-Windows applications based on the current image.
-      The canvas must be square. Remeber that iOS does not support alpha channels in their icons.
+      The canvas must be square. Remember that iOS does not support alpha channels in their icons.
     </param>
 
-    <param name="name"                  type="string"  gui-text="Icon Filename (without extension, without path):"      >icon</param>
+    <param name="name"                  type="string"  gui-text="Icon Filename (without extension, without path):"                 >icon</param>
 
-    <param name="ios_icons"             type="boolean" gui-text="iOS Icons"                                             >true</param>
-    <param name="ios_path"              type="string"  gui-text="Directory to save IOS images to:"                      >/tmp</param>
+    <param name="ios_icons"             type="boolean" gui-text="iOS Icons"                                                        >true</param>
+    <param name="ios_path"              type="path" mode="folder" gui-text="Directory to save IOS images to:"                      >/tmp</param>
 
-    <param name="android_mipmap"        type="boolean" gui-text="Create Android MipMap dirs"                            >true</param>
-    <param name="android_drawable"      type="boolean" gui-text="Create Android Drawable dirs"                          >true</param>
-    <param name="android_tvdpi"         type="boolean" gui-text="Add TV Resolution"                                     >true</param>
-    <param name="android_basepx"        type="string"  gui-text="Base Px (normally 48)"                                 >48</param>
-    <param name="android_path"          type="string"  gui-text="The res directory in your android path:"               >/tmp/res</param>
+    <param name="android_mipmap"        type="boolean" gui-text="Create Android MipMap dirs"                                       >true</param>
+    <param name="android_drawable"      type="boolean" gui-text="Create Android Drawable dirs"                                     >true</param>
+    <param name="android_tvdpi"         type="boolean" gui-text="Add TV Resolution"                                                >true</param>
+    <param name="android_basepx"        type="string"  gui-text="Base Px (normally 48)"                                            >48</param>
+    <param name="android_path"          type="string"  gui-text="The res directory in your android path:"                          >/tmp/res</param>
 
-    <param name="windows_icons"         type="boolean" gui-text="Windows Icons"                                         >true</param>
-    <param name="windows_one_ico_file"  type="boolean" gui-text="Also create one ICO file (PNG Based)"                  >true</param>
-    <param name="windows_path"          type="string"  gui-text="The windows directory you want to save the icons to:"  >/tmp</param>
+    <param name="windows_icons"         type="boolean" gui-text="Windows Icons"                                                    >true</param>
+    <param name="windows_one_ico_file"  type="boolean" gui-text="Also create one ICO file (PNG Based)"                             >true</param>
+    <param name="windows_path"          type="path" mode="folder" gui-text="The windows directory you want to save the icons to:"  >/tmp</param>
 
     <effect>
         <object-type>all</object-type>

--- a/app_icon.py
+++ b/app_icon.py
@@ -102,7 +102,7 @@ class GenerateIconsEffect(inkex.Effect):
             icon_base_name                    = self.options.name
 
             svg = self.document.getroot()
-            currentFileName = self.args[-1]
+            currentFileName = self.options.input_file
             
             #saveDir = os.path.expanduser("~") #saves icons to the home directory
             IOS_ICON_RESOLUTIONS = [1024, 1024, 167, 152, 76, 180, 120, 120, 80, 40, 87, 58, 29, 60, 40, 20]

--- a/app_icon.py
+++ b/app_icon.py
@@ -6,7 +6,6 @@
 #          Carlos Vazquez initial version
 # 20200408 Ron AF Greve Splitted android dirs in mipmap and drawables and added windows icon and ICO file. Added path variables.
 
-
 import inkex
 from simplestyle import *
 from lxml import etree
@@ -14,6 +13,7 @@ import os
 #from pathlib import Path
 import traceback
 import sys
+
 
 class WindowsIconInfo():
     # Note the windows icon file can either be a ICO or CUR file 
@@ -105,25 +105,15 @@ class GenerateIconsEffect(inkex.Effect):
             currentFileName = self.args[-1]
             
             #saveDir = os.path.expanduser("~") #saves icons to the home directory
+            IOS_ICON_RESOLUTIONS = [1024, 1024, 167, 152, 76, 180, 120, 120, 80, 40, 87, 58, 29, 60, 40, 20]
+
             if ios_icons == "true":
                 self.makePath(ios_path)
+                for resolution in IOS_ICON_RESOLUTIONS:
+                    ios_icon_name = "Icon-App-{res}x{res}@1x.png".format(res=resolution)
+                    output_file = os.path.join(ios_path, ios_icon_name)
+                    os.system("inkscape -e " + output_file + " -f " + currentFileName)
 
-                os.system("inkscape -e " + ios_path + "Icon-App-1024x1024@1x.png -h 1024 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-1024x1024@1x.png -h 1024 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-83.5x83.5@2x.png -h 167 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-76x76@2x.png -h 152 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-76x76@1x.png -h 76 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-60x60@3x.png -h 180 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-60x60@2x.png -h 120 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-40x40@3x.png -h 120 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-40x40@2x.png -h 80 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-40x40@1x.png -h 40 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-29x29@3x.png -h 87 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-29x29@2x.png -h 58 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-29x29@1x.png -h 29 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-20x20@3x.png -h 60 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-20x20@2x.png -h 40 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-20x20@1x.png -h 20 -f " + currentFileName)
                 # inkex.errormsg(_("saving to: " + ios_path))
 
             if android_mipmap == "true" or android_drawable == "true":

--- a/app_icon.py
+++ b/app_icon.py
@@ -29,7 +29,7 @@ def export_image(source, output, resolution=None):
     args = [source, "-o", output]
     if resolution:
         args += ["-h", str(resolution)]
-    debug(args)
+    debug("Calling Inkscape with args %s" % args)
     command.inkscape(*args)
 
 
@@ -128,7 +128,7 @@ class GenerateIconsEffect(inkex.Effect):
                 self.makePath(ios_path)
                 for resolution in IOS_ICON_RESOLUTIONS:
                     ios_icon_name = "Icon-App-{res}x{res}@1x.png".format(res=resolution)
-                    debug('exporting ios image %s' % ios_icon_name)
+                    debug('Exporting ios image %s' % ios_icon_name)
                     export_image(
                         currentFileName,
                         os.path.join(ios_path, ios_icon_name),
@@ -228,9 +228,9 @@ class GenerateIconsEffect(inkex.Effect):
         self.CurrentOffset = self.CurrentOffset + Filesize
 
     def WriteFile( self, ByteArray, WindowsIconInfo ):
-        File = open( WindowsIconInfo.GetImagePath(), "rb" )
-        ByteArrayFile = bytearray( File.read() )
-        ByteArray.extend( ByteArrayFile )
+        with open( WindowsIconInfo.GetImagePath(), "rb" ) as File:
+            ByteArrayFile = bytearray( File.read() )
+            ByteArray.extend( ByteArrayFile )
         
         
     def CreateIconFile( self, Filename, Type ):
@@ -259,8 +259,8 @@ class GenerateIconsEffect(inkex.Effect):
             self.WriteFile( ByteArray, WindowsIconInfo )      
 
         # -- Output to a file
-        File = open( Filename, "wb" )
-        File.write( ByteArray )
+        with open( Filename, "wb" ) as File:
+            File.write( ByteArray )
 
 
 

--- a/app_icon.py
+++ b/app_icon.py
@@ -252,8 +252,8 @@ class GenerateIconsEffect(inkex.Effect):
 
         #get document and make sure it is a square
         svg = self.document.getroot()
-        width  = self.unittouu(svg.get('width'))
-        height = self.unittouu(svg.attrib['height'])
+        width  = self.svg.unittouu(svg.get('width'))
+        height = self.svg.unittouu(svg.attrib['height'])
 
         if width != height:
             inkex.errormsg(_("Canvas is not square"))

--- a/app_icon.py
+++ b/app_icon.py
@@ -47,40 +47,33 @@ class GenerateIconsEffect(inkex.Effect):
 
     def __init__(self):
         inkex.Effect.__init__(self)
-        self.OptionParser.add_option('-k', '--ios_icons', action = 'store',
-          type = 'string', dest = 'ios_icons', default = 'false',
-          help = 'Create ios icons?')
-        self.OptionParser.add_option('-i', '--ios_path', action = 'store',
-          type = 'string', dest = 'ios_path', default = 'false',
-          help = 'Path where the ios icons are stored')
-        self.OptionParser.add_option('-m', '--android_mipmap', action = 'store',
-          type = 'string', dest = 'android_mipmap', default = 'false',
-          help = 'Create android mipmap dirs and icons?')
-        self.OptionParser.add_option('-d', '--android_drawable', action = 'store',
-          type = 'string', dest = 'android_drawable', default = 'false',
-          help = 'Create android drawable dirs and icons?')
-        self.OptionParser.add_option('-a', '--android_path', action = 'store',
-          type = 'string', dest = 'android_path', default = 'false',
-          help = 'Path to and including the android res directory')
-        self.OptionParser.add_option('-t', '--android_tvdpi', action = 'store',
-          type = 'string', dest = 'android_tvdpi', default = 'false',
-          help = 'Add android TV resolution')
-        self.OptionParser.add_option('-b', '--android_basepx', action = 'store',
-          type = 'string', dest = 'android_basepx', default = 'false',
-          help = 'Add android TV resolution')
-        self.OptionParser.add_option('-x', '--windows_icons', action = 'store',
-          type = 'string', dest = 'windows_icons', default = 'false',
-          help = 'Create windows icons?')
-        self.OptionParser.add_option('-c', '--windows_one_ico_file', action = 'store',
-          type = 'string', dest = 'windows_one_ico_file', default = 'false',
-          help = 'Create one windows ico file?')
-        self.OptionParser.add_option('-w', '--windows_path', action = 'store',
-          type = 'string', dest = 'windows_path', default = 'false',
-          help = 'Path where the windows icons are stored')
 
-        self.OptionParser.add_option('-n', '--name', action = 'store',
-          type = 'string', dest = 'name', default = 'false',
-          help = 'Name of image file without extension or path')
+        # Arguments for generating ios icons
+        self.arg_parser.add_argument('-k', '--ios_icons', dest='ios_icons', default='false',
+                                     help='Create ios icons?')
+        self.arg_parser.add_argument('-i', '--ios_path', dest='ios_path', help='Path where the ios icons are stored')
+
+        # Arguments for generating Android icons
+        self.arg_parser.add_argument('-m', '--android_mipmap', dest='android_mipmap', default='false',
+                                     help='Create android mipmap dirs and icons?')
+        self.arg_parser.add_argument('-d', '--android_drawable', dest='android_drawable', default='false',
+                                     help='Create android drawable dirs and icons?')
+        self.arg_parser.add_argument('-a', '--android_path', dest='android_path', default='false',
+                                     help='Path to and including the android res directory')
+        self.arg_parser.add_argument('-t', '--android_tvdpi', dest='android_tvdpi', default='false',
+                                     help='Add android TV resolution')
+        self.arg_parser.add_argument('-b', '--android_basepx', dest='android_basepx', default='false',
+                                     help='Add android TV resolution')
+
+        # Arguments for generating Windows icons
+        self.arg_parser.add_argument('-x', '--windows_icons', dest='windows_icons', default='false',
+                                     help='Create windows icons?')
+        self.arg_parser.add_argument('-c', '--windows_one_ico_file', dest='windows_one_ico_file', default='false',
+                                     help='Create one windows ico file?')
+        self.arg_parser.add_argument('-w', '--windows_path', dest='windows_path',
+                                     help='Path where the windows icons are stored')
+        self.arg_parser.add_argument('-n', '--name', dest='name', default='false',
+                                     help='Name of image file without extension or path')
    
     def NormalizeDir( self, Directory ):
         if len( Directory ) == 0:

--- a/app_icon.py
+++ b/app_icon.py
@@ -267,4 +267,4 @@ class GenerateIconsEffect(inkex.Effect):
 
 # Create effect instance and apply it.
 effect = GenerateIconsEffect()
-effect.affect()
+effect.run()

--- a/app_icon.py
+++ b/app_icon.py
@@ -97,7 +97,7 @@ class GenerateIconsEffect(inkex.Effect):
         # make sure the doc meets the requirements
         passing = self.runTests()
 
-        if passing == False:
+        if not passing:
             inkex.errormsg(_("Errors encountered. Please fix them and try again."))
             exit()
         else:


### PR DESCRIPTION
Extension should work on windows and linux now with the latest version of Inkscape.

- Removed os.system calls and replaced with inkex.command calls.
- Resolve deprecation warnings for option parser, unitouu, input_file, and affect vs. run calls.
- use os.path instead of string concatenation.
- handle unsafe file writes 
- provide ios/windows resolutions as arrays for easier updating
- new debug and export_image methods for convenience.

Unhandled:  Refactor to PEP 8 standards.   Seemed like the code was already opinionated so I left that alone for the most part.