### PR TITLE
Update to support Inkscape 1.0.1

### DIFF
--- a/app_icon.py
+++ b/app_icon.py
@@ -165,7 +165,7 @@ class GenerateIconsEffect(inkex.Effect):
                 if android_tvdpi == "true":
                     DensityMap.update( { "tvdpi" : 4 * 1.33 } )
 
-                for Density, Ratio in DensityMap.items():
+                for Density, Ratio in list(DensityMap.items()):
                     DensityInPx = ( Ratio * android_basepx ) / 4
                     for DirectoryPrefix in DirectoryPrefixes:
                         FullPath = android_path + DirectoryPrefix + "-" + Density + "/" 

--- a/app_icon.py
+++ b/app_icon.py
@@ -47,39 +47,39 @@ class GenerateIconsEffect(inkex.Effect):
 
     def __init__(self):
         inkex.Effect.__init__(self)
-        self.OptionParser.add_option('-k', '--ios_icons', action = 'store',
-          type = 'string', dest = 'ios_icons', default = 'false',
+        self.arg_parser.add_argument('-k', '--ios_icons', action = 'store',
+          type = str, dest = 'ios_icons', default = 'false',
           help = 'Create ios icons?')
-        self.OptionParser.add_option('-i', '--ios_path', action = 'store',
-          type = 'string', dest = 'ios_path', default = 'false',
+        self.arg_parser.add_argument('-i', '--ios_path', action = 'store',
+          type = str, dest = 'ios_path', default = 'false',
           help = 'Path where the ios icons are stored')
-        self.OptionParser.add_option('-m', '--android_mipmap', action = 'store',
-          type = 'string', dest = 'android_mipmap', default = 'false',
+        self.arg_parser.add_argument('-m', '--android_mipmap', action = 'store',
+          type = str, dest = 'android_mipmap', default = 'false',
           help = 'Create android mipmap dirs and icons?')
-        self.OptionParser.add_option('-d', '--android_drawable', action = 'store',
-          type = 'string', dest = 'android_drawable', default = 'false',
+        self.arg_parser.add_argument('-d', '--android_drawable', action = 'store',
+          type = str, dest = 'android_drawable', default = 'false',
           help = 'Create android drawable dirs and icons?')
-        self.OptionParser.add_option('-a', '--android_path', action = 'store',
-          type = 'string', dest = 'android_path', default = 'false',
+        self.arg_parser.add_argument('-a', '--android_path', action = 'store',
+          type = str, dest = 'android_path', default = 'false',
           help = 'Path to and including the android res directory')
-        self.OptionParser.add_option('-t', '--android_tvdpi', action = 'store',
-          type = 'string', dest = 'android_tvdpi', default = 'false',
+        self.arg_parser.add_argument('-t', '--android_tvdpi', action = 'store',
+          type = str, dest = 'android_tvdpi', default = 'false',
           help = 'Add android TV resolution')
-        self.OptionParser.add_option('-b', '--android_basepx', action = 'store',
-          type = 'string', dest = 'android_basepx', default = 'false',
+        self.arg_parser.add_argument('-b', '--android_basepx', action = 'store',
+          type = str, dest = 'android_basepx', default = 'false',
           help = 'Add android TV resolution')
-        self.OptionParser.add_option('-x', '--windows_icons', action = 'store',
-          type = 'string', dest = 'windows_icons', default = 'false',
+        self.arg_parser.add_argument('-x', '--windows_icons', action = 'store',
+          type = str, dest = 'windows_icons', default = 'false',
           help = 'Create windows icons?')
-        self.OptionParser.add_option('-c', '--windows_one_ico_file', action = 'store',
-          type = 'string', dest = 'windows_one_ico_file', default = 'false',
+        self.arg_parser.add_argument('-c', '--windows_one_ico_file', action = 'store',
+          type = str, dest = 'windows_one_ico_file', default = 'false',
           help = 'Create one windows ico file?')
-        self.OptionParser.add_option('-w', '--windows_path', action = 'store',
-          type = 'string', dest = 'windows_path', default = 'false',
+        self.arg_parser.add_argument('-w', '--windows_path', action = 'store',
+          type = str, dest = 'windows_path', default = 'false',
           help = 'Path where the windows icons are stored')
 
-        self.OptionParser.add_option('-n', '--name', action = 'store',
-          type = 'string', dest = 'name', default = 'false',
+        self.arg_parser.add_argument('-n', '--name', action = 'store',
+          type = str, dest = 'name', default = 'false',
           help = 'Name of image file without extension or path')
    
     def NormalizeDir( self, Directory ):
@@ -121,28 +121,28 @@ class GenerateIconsEffect(inkex.Effect):
             
 
             svg = self.document.getroot()
-            currentFileName = self.args[-1]
+            currentFileName = self.options.input_file
             
             #saveDir = os.path.expanduser("~") #saves icons to the home directory
             if ios_icons == "true":
                 self.makePath(ios_path)
 
-                os.system("inkscape -e " + ios_path + "Icon-App-1024x1024@1x.png -h 1024 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-1024x1024@1x.png -h 1024 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-83.5x83.5@2x.png -h 167 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-76x76@2x.png -h 152 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-76x76@1x.png -h 76 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-60x60@3x.png -h 180 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-60x60@2x.png -h 120 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-40x40@3x.png -h 120 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-40x40@2x.png -h 80 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-40x40@1x.png -h 40 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-29x29@3x.png -h 87 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-29x29@2x.png -h 58 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-29x29@1x.png -h 29 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-20x20@3x.png -h 60 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-20x20@2x.png -h 40 -f " + currentFileName)
-                os.system("inkscape -e " + ios_path + "Icon-App-20x20@1x.png -h 20 -f " + currentFileName)
+                os.system("inkscape -o " + ios_path + "Icon-App-1024x1024@1x.png -h 1024 " + currentFileName)
+                os.system("inkscape -o " + ios_path + "Icon-App-1024x1024@1x.png -h 1024 " + currentFileName)
+                os.system("inkscape -o " + ios_path + "Icon-App-83.5x83.5@2x.png -h 167 " + currentFileName)
+                os.system("inkscape -o " + ios_path + "Icon-App-76x76@2x.png -h 152 " + currentFileName)
+                os.system("inkscape -o " + ios_path + "Icon-App-76x76@1x.png -h 76 " + currentFileName)
+                os.system("inkscape -o " + ios_path + "Icon-App-60x60@3x.png -h 180 " + currentFileName)
+                os.system("inkscape -o " + ios_path + "Icon-App-60x60@2x.png -h 120 " + currentFileName)
+                os.system("inkscape -o " + ios_path + "Icon-App-40x40@3x.png -h 120 " + currentFileName)
+                os.system("inkscape -o " + ios_path + "Icon-App-40x40@2x.png -h 80 " + currentFileName)
+                os.system("inkscape -o " + ios_path + "Icon-App-40x40@1x.png -h 40 " + currentFileName)
+                os.system("inkscape -o " + ios_path + "Icon-App-29x29@3x.png -h 87 " + currentFileName)
+                os.system("inkscape -o " + ios_path + "Icon-App-29x29@2x.png -h 58 " + currentFileName)
+                os.system("inkscape -o " + ios_path + "Icon-App-29x29@1x.png -h 29 " + currentFileName)
+                os.system("inkscape -o " + ios_path + "Icon-App-20x20@3x.png -h 60 " + currentFileName)
+                os.system("inkscape -o " + ios_path + "Icon-App-20x20@2x.png -h 40 " + currentFileName)
+                os.system("inkscape -o " + ios_path + "Icon-App-20x20@1x.png -h 20 " + currentFileName)
                 # inkex.errormsg(_("saving to: " + ios_path))
 
             if android_mipmap == "true" or android_drawable == "true":
@@ -155,7 +155,7 @@ class GenerateIconsEffect(inkex.Effect):
                     DirectoryPrefixes.append( "drawable" )
                 
                 self.makePath( android_path )
-                #os.system("inkscape -e " + path + "Icon-xxxhdpi.png -h 192 -f " + currentFileName)
+                #os.system("inkscape -o " + path + "Icon-xxxhdpi.png -h 192 " + currentFileName)
 
                 # Densities calculated of baseline in ratios 3:4:6:8:12:16
                 # Where 4 correspons to mdpi the baseline dpi (for instance 48 so the divisor = 12)
@@ -170,14 +170,14 @@ class GenerateIconsEffect(inkex.Effect):
                     for DirectoryPrefix in DirectoryPrefixes:
                         FullPath = android_path + DirectoryPrefix + "-" + Density + "/" 
                         self.makePath( FullPath )
-                        os.system( "inkscape -e " + FullPath + name + ".png -h " + str( DensityInPx ) + " -f " + currentFileName )
+                        os.system( "inkscape -o " + FullPath + name + ".png -h " + str( DensityInPx ) + " " + currentFileName )
 
             if windows_icons == "true" or windows_one_ico_file == "true":
                 self.makePath( windows_path )
                 Resolutions = [ 256, 128, 64, 48, 32, 24, 16, 12, 8 ]
                 for Resolution in Resolutions:
                     ImagePath = windows_path + name + "-" + str( Resolution ) + ".png" 
-                    os.system("inkscape -e " + ImagePath + " -h " + str( Resolution ) + " -f " + currentFileName)
+                    os.system("inkscape -o " + ImagePath + " -h " + str( Resolution ) + " " + currentFileName)
                     self.WindowsIconCurList.append( WindowsIconInfo( ImagePath, Resolution ) )
                 if windows_one_ico_file == "true":                
                     self.CreateIconFile( windows_path + name + ".ico", 1 )
@@ -276,8 +276,8 @@ class GenerateIconsEffect(inkex.Effect):
 
         #get document and make sure it is a square
         svg = self.document.getroot()
-        width  = self.unittouu(svg.get('width'))
-        height = self.unittouu(svg.attrib['height'])
+        width  = self.svg.unittouu(svg.get('width'))
+        height = self.svg.unittouu(svg.attrib['height'])
 
         if width != height:
             inkex.errormsg(_("Canvas is not square"))
@@ -292,4 +292,4 @@ class GenerateIconsEffect(inkex.Effect):
 
 # Create effect instance and apply it.
 effect = GenerateIconsEffect()
-effect.affect()
+effect.run()


### PR DESCRIPTION
Several updates required to run on Inkscape 1.0.1

- Update to Python 3 (using 2to3.py helper script)
- Update usage of optparse with argparser
- Update usage of Inkscape command line